### PR TITLE
adds extra check for browser common.js

### DIFF
--- a/src/tcp-socket.js
+++ b/src/tcp-socket.js
@@ -27,7 +27,7 @@
     } else if (typeof define === 'function' && define.amd && typeof nodeRequire !== 'undefined') {
         // amd under node-webkit
         define([], factory.bind(null, navigator, null, nodeRequire('net'), nodeRequire('tls')));
-    } else if (typeof exports === 'object' && typeof navigator !== 'undefined') {
+    } else if (typeof exports === 'object' && typeof navigator !== 'undefined' && typeof process === 'undefined') {
         // common.js for browser apps with native socket support
         module.exports = factory(navigator, require('./tcp-socket-tls'));
     } else if (typeof exports === 'object') {


### PR DESCRIPTION
I've been trying to use tcp-socket from within an electron app and I
stumbled upon a problem: navigator is present, so it detects it as a
common.js for browser when node.js `net` and `tls` could be used.

I hope that makes sense!