### PR TITLE
Revert "adds extra check for browser common.js"

### DIFF
--- a/src/tcp-socket.js
+++ b/src/tcp-socket.js
@@ -27,7 +27,7 @@
     } else if (typeof define === 'function' && define.amd && typeof nodeRequire !== 'undefined') {
         // amd under node-webkit
         define([], factory.bind(null, navigator, null, nodeRequire('net'), nodeRequire('tls')));
-    } else if (typeof exports === 'object' && typeof navigator !== 'undefined' && typeof process === 'undefined') {
+    } else if (typeof exports === 'object' && typeof navigator !== 'undefined') {
         // common.js for browser apps with native socket support
         module.exports = factory(navigator, require('./tcp-socket-tls'));
     } else if (typeof exports === 'object') {


### PR DESCRIPTION
Reverts whiteout-io/tcp-socket#19

This change broke the browserify build for all other platforms.